### PR TITLE
feat: Add more brokertopic and controller metrics

### DIFF
--- a/src/args/args.go
+++ b/src/args/args.go
@@ -89,4 +89,6 @@ type ArgumentList struct {
 	ShowVersion bool `default:"false" help:"Print build information and exit"`
 
 	TopicSource string `default:"broker" help:"Collect topics list from either the Broker or Zookeeper"`
+
+	EnableBrokerTopicMetricsV2 bool `default:"false" help:"Enable the new BrokerTopicMetrics metrics. This is a new set of metrics that are essentials for some capabilities to work. "`
 }

--- a/src/args/parsed_args.go
+++ b/src/args/parsed_args.go
@@ -90,6 +90,7 @@ type ParsedArguments struct {
 	TopicBucket                TopicBucket
 	CollectTopicSize           bool
 	CollectTopicOffset         bool
+	EnableBrokerTopicMetricsV2 bool
 
 	// Consumer offset arguments
 	ConsumerOffset              bool
@@ -252,6 +253,8 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		return nil, fmt.Errorf("failed to parse kafka version: %s", err)
 	}
 
+	log.Info("Processing new BrokerTopic metrics flag is : %v", a.EnableBrokerTopicMetricsV2)
+
 	parsedArgs := &ParsedArguments{
 		DefaultArgumentList:              a.DefaultArgumentList,
 		AutodiscoverStrategy:             a.AutodiscoverStrategy,
@@ -301,6 +304,7 @@ func ParseArgs(a ArgumentList) (*ParsedArguments, error) {
 		SaslGssapiKerberosConfigPath:     a.SaslGssapiKerberosConfigPath,
 		SaslGssapiDisableFASTNegotiation: a.SaslGssapiDisableFASTNegotiation,
 		TopicSource:                      a.TopicSource,
+		EnableBrokerTopicMetricsV2: 	  a.EnableBrokerTopicMetricsV2,
 	}
 
 	return parsedArgs, nil

--- a/src/broker/broker_collection.go
+++ b/src/broker/broker_collection.go
@@ -182,7 +182,7 @@ func collectBrokerTopicMetrics(b *connection.Broker, collectedTopics []string, i
 		// Insert into map
 		topicSampleLookup[topicName] = sample
 
-		metrics.CollectMetricDefinitions(sample, metrics.BrokerTopicMetricDefs, metrics.ApplyTopicName(topicName), conn)
+		metrics.CollectMetricDefinitions(sample, metrics.GetFinalMetricSets(metrics.BrokerTopicMetricDefs, metrics.BrokerTopicV2MetricDefs), metrics.ApplyTopicName(topicName), conn)
 	}
 
 	return topicSampleLookup

--- a/src/metrics/broker_definitions.go
+++ b/src/metrics/broker_definitions.go
@@ -46,6 +46,26 @@ var brokerRequestMetricDefs = []*JMXMetricSet{
 	},
 }
 
+var BrokerV2MetricDefs = []*JMXMetricSet{
+	// Controller Metrics
+	{
+		MBean:        "kafka.controller:type=KafkaController,name=*",
+		MetricPrefix: "kafka.controller:type=KafkaController,",
+		MetricDefs: []*MetricDefinition{
+			{
+				Name:       "broker.ActiveControllerCount",
+				SourceType: metric.GAUGE,
+				JMXAttr:    "name=ActiveControllerCount,attr=Value",
+			},
+			{
+				Name:       "broker.GlobalPartitionCount",
+				SourceType: metric.GAUGE,
+				JMXAttr:    "name=GlobalPartitionCount,attr=Value",
+			},
+		},
+	},
+}
+
 // Broker metrics
 var brokerMetricDefs = []*JMXMetricSet{
 	// Metadata request Metrics
@@ -260,6 +280,32 @@ var BrokerTopicMetricDefs = []*JMXMetricSet{
 		MetricDefs: []*MetricDefinition{
 			{
 				Name:       "broker.bytesWrittenToTopicPerSecond",
+				SourceType: metric.RATE,
+				JMXAttr:    "attr=Count",
+			},
+		},
+	},
+}
+
+// BrokerTopicMetricDefs metric definitions for topic metrics that are specific to a Broker
+var BrokerTopicV2MetricDefs = []*JMXMetricSet{
+	{
+		MBean:        "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=" + topicHolder,
+		MetricPrefix: "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=" + topicHolder + ",",
+		MetricDefs: []*MetricDefinition{
+			{
+				Name:       "broker.bytesReadFromTopicPerSecond",
+				SourceType: metric.RATE,
+				JMXAttr:    "attr=Count",
+			},
+		},
+	},
+	{
+		MBean:        "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=" + topicHolder,
+		MetricPrefix: "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=" + topicHolder + ",",
+		MetricDefs: []*MetricDefinition{
+			{
+				Name:       "broker.messagesProducedToTopicPerSecond",
 				SourceType: metric.RATE,
 				JMXAttr:    "attr=Count",
 			},

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -22,8 +22,21 @@ import (
 
 // GetBrokerMetrics collects all Broker JMX metrics and stores them in sample
 func GetBrokerMetrics(sample *metric.Set, conn connection.JMXConnection) {
-	CollectMetricDefinitions(sample, brokerMetricDefs, nil, conn)
+	CollectMetricDefinitions(sample, GetFinalMetricSets(brokerMetricDefs, BrokerV2MetricDefs), nil, conn)
 	CollectBrokerRequestMetrics(sample, brokerRequestMetricDefs, conn)
+}
+
+func GetFinalMetricSets(metricSets []*JMXMetricSet, v2MetricSets []*JMXMetricSet) []*JMXMetricSet {
+	log.Info("Initial metric sets: %v , %v", metricSets, v2MetricSets)
+    finalMetricSets := make([]*JMXMetricSet, 0, len(metricSets)+len(v2MetricSets))
+    finalMetricSets = append(finalMetricSets, metricSets...)
+
+    if args.GlobalArgs.EnableBrokerTopicMetricsV2 {
+        finalMetricSets = append(finalMetricSets, v2MetricSets...)
+    }
+
+	log.Info("Final metric sets: %v", finalMetricSets)
+    return finalMetricSets
 }
 
 // GetConsumerMetrics collects all Consumer metrics for the given

--- a/tests/integration/json-schema-files/kafka-schema-metrics-v2.json
+++ b/tests/integration/json-schema-files/kafka-schema-metrics-v2.json
@@ -165,55 +165,12 @@
                 "items": {
                   "allOf": [
                     {
-                      "not": {
-                        "type": "object",
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "required": ["broker.ActiveControllerCount"],
-                            "properties": {
-                              "broker.ActiveControllerCount": {
-                                "type": "number"
-                              }
-                            }
-                          },
-                          {
-                            "type": "object",
-                            "required": ["broker.GlobalPartitionCount"],
-                            "properties": {
-                              "broker.GlobalPartitionCount": {
-                                "type": "number"
-                              }
-                            }
-                          },
-                          {
-                            "type": "object",
-                            "required": ["broker.bytesReadFromTopicPerSecond"],
-                            "properties": {
-                              "broker.bytesReadFromTopicPerSecond": {
-                                "type": "number"
-                              }
-                            }
-                          },
-                          {
-                            "type": "object",
-                            "required": [
-                              "broker.messagesProducedToTopicPerSecond"
-                            ],
-                            "properties": {
-                              "broker.messagesProducedToTopicPerSecond": {
-                                "type": "number"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
                       "anyOf": [
                         {
                           "type": "object",
                           "required": [
+                            "broker.ActiveControllerCount",
+                            "broker.GlobalPartitionCount",
                             "broker.IOInPerSecond",
                             "broker.IOOutPerSecond",
                             "broker.messagesInPerSecond",
@@ -227,6 +184,12 @@
                             "replication.unreplicatedPartitions"
                           ],
                           "properties": {
+                            "broker.ActiveControllerCount": {
+                              "type": "number"
+                            },
+                            "broker.GlobalPartitionCount": {
+                              "type": "number"
+                            },
                             "broker.IOInPerSecond": {
                               "type": "integer"
                             },
@@ -328,6 +291,41 @@
                             },
                             "topic": {
                               "type": "string"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "clusterName",
+                            "displayName",
+                            "entityName",
+                            "event_type",
+                            "topic",
+                            "broker.bytesReadFromTopicPerSecond",
+                            "broker.messagesProducedToTopicPerSecond"
+                          ],
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "displayName": {
+                              "type": "string"
+                            },
+                            "entityName": {
+                              "type": "string"
+                            },
+                            "event_type": {
+                              "type": "string"
+                            },
+                            "topic": {
+                              "type": "string"
+                            },
+                            "broker.bytesReadFromTopicPerSecond": {
+                              "type": "number"
+                            },
+                            "broker.messagesProducedToTopicPerSecond": {
+                              "type": "number"
                             }
                           }
                         }

--- a/tests/integration/kafka_test.go
+++ b/tests/integration/kafka_test.go
@@ -330,6 +330,24 @@ func TestKafkaIntegration_bootstrap_metrics(t *testing.T) {
 	}
 }
 
+func TestKafkaIntegration_bootstrap_new_metrics(t *testing.T) {
+	bootstrapDiscoverConfigMetrics := func(command []string) []string {
+		return append(bootstrapDiscoverConfig(command), "--metrics", "--enable_broker_topic_metrics_v2")
+	}
+
+	stdout, stderr, err := runIntegration(t, bootstrapDiscoverConfigMetrics)
+
+	assert.NotNil(t, stderr, "unexpected stderr")
+	assert.NoError(t, err, "Unexpected error")
+
+	schemaPath := filepath.Join("json-schema-files", "kafka-schema-metrics-v2.json")
+	err = jsonschema.Validate(schemaPath, stdout)
+	assert.NoError(t, err, "The output of kafka integration doesn't have expected format.")
+	for _, topic := range topicNames {
+		assert.Contains(t, stdout, topic, fmt.Sprintf("The output doesn't have the topic %s", topic))
+	}
+}
+
 func TestKafkaIntegration_bootstrap_inventory(t *testing.T) {
 	bootstrapDiscoverConfigInventory := func(command []string) []string {
 		return append(bootstrapDiscoverConfig(command), "--inventory")


### PR DESCRIPTION
Introducing new config `ENABLE_BROKER_TOPIC_METRICS_V2` in nri-kafka

To enable processing additional metrics. Below are metric details

- Metric: kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=* topic level
- Metric: kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=* topic level
- Metric: kafka.controller:type=KafkaController,name=ActiveControllerCount broker level
- Metric: kafka.controller:type=KafkaController,name=GlobalPartitionCount broker level